### PR TITLE
Cleanup

### DIFF
--- a/faas_grip.py
+++ b/faas_grip.py
@@ -1,14 +1,21 @@
+import json
 import os
 import sys
+import threading
+import types
 from base64 import b64encode, b64decode
 from struct import pack
-import threading
-import json
-import types
+
 import six
+from gripcontrol import (
+    GripPubControl,
+    WebSocketContext,
+    WebSocketEvent,
+    decode_websocket_events,
+    encode_websocket_events,
+    parse_grip_uri
+)
 from pubcontrol import Item
-from gripcontrol import GripPubControl, WebSocketEvent, WebSocketContext, \
-    parse_grip_uri, decode_websocket_events, encode_websocket_events
 
 is_python3 = sys.version_info >= (3,)
 

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -25,13 +25,7 @@ _lock = threading.Lock()
 
 
 def _is_basestring_instance(instance):
-    try:
-        if isinstance(instance, basestring):
-            return True
-    except NameError:
-        if isinstance(instance, str):
-            return True
-    return False
+    return isinstance(instance, six.string_types)
 
 
 def _get_proxies():

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -8,7 +8,7 @@ import types
 import six
 from pubcontrol import Item
 from gripcontrol import GripPubControl, WebSocketEvent, WebSocketContext, \
-	parse_grip_uri, decode_websocket_events, encode_websocket_events
+    parse_grip_uri, decode_websocket_events, encode_websocket_events
 
 is_python3 = sys.version_info >= (3,)
 
@@ -17,132 +17,132 @@ _pubcontrol = None
 _lock = threading.Lock()
 
 def _is_basestring_instance(instance):
-	try:
-		if isinstance(instance, basestring):
-			return True
-	except NameError:
-		if isinstance(instance, str):
-			return True
-	return False
+    try:
+        if isinstance(instance, basestring):
+            return True
+    except NameError:
+        if isinstance(instance, str):
+            return True
+    return False
 
 def _get_proxies():
-	proxies = []
-	grip_proxies = os.environ.get('GRIP_PROXIES')
-	if grip_proxies:
-		proxies.extend(json.loads(grip_proxies))
-	grip_url = os.environ.get('GRIP_URL')
-	if grip_url:
-		proxies.append(parse_grip_uri(grip_url))
-	return proxies
+    proxies = []
+    grip_proxies = os.environ.get('GRIP_PROXIES')
+    if grip_proxies:
+        proxies.extend(json.loads(grip_proxies))
+    grip_url = os.environ.get('GRIP_URL')
+    if grip_url:
+        proxies.append(parse_grip_uri(grip_url))
+    return proxies
 
 def _get_pubcontrol():
-	global _pubcontrol
-	_lock.acquire()
-	if _pubcontrol is None:
-		_pubcontrol = GripPubControl()
-		_pubcontrol.apply_grip_config(_get_proxies())
-	_lock.release()
-	return _pubcontrol
+    global _pubcontrol
+    _lock.acquire()
+    if _pubcontrol is None:
+        _pubcontrol = GripPubControl()
+        _pubcontrol.apply_grip_config(_get_proxies())
+    _lock.release()
+    return _pubcontrol
 
 def _get_prefix():
-	return os.environ.get('GRIP_PREFIX', '')
+    return os.environ.get('GRIP_PREFIX', '')
 
 def get_pubcontrol():
-	return _get_pubcontrol()
+    return _get_pubcontrol()
 
 def publish(channel, formats, id=None, prev_id=None, blocking=True, callback=None, meta={}):
-	pub = _get_pubcontrol()
-	pub.publish(_get_prefix() + channel,
-		Item(formats, id=id, prev_id=prev_id, meta=meta),
-		blocking=blocking,
-		callback=callback)
+    pub = _get_pubcontrol()
+    pub.publish(_get_prefix() + channel,
+        Item(formats, id=id, prev_id=prev_id, meta=meta),
+        blocking=blocking,
+        callback=callback)
 
 def lambda_websocket_to_response(wscontext):
-	# meta to remove?
-	meta_remove = set()
-	for k, v in six.iteritems(wscontext.orig_meta):
-		found = False
-		for nk, nv in six.iteritems(wscontext.meta):
-			if nk.lower() == k:
-				found = True
-				break
-		if not found:
-			meta_remove.add(k)
+    # meta to remove?
+    meta_remove = set()
+    for k, v in six.iteritems(wscontext.orig_meta):
+        found = False
+        for nk, nv in six.iteritems(wscontext.meta):
+            if nk.lower() == k:
+                found = True
+                break
+        if not found:
+            meta_remove.add(k)
 
-	# meta to set?
-	meta_set = {}
-	for k, v in six.iteritems(wscontext.meta):
-		lname = k.lower()
-		need_set = True
-		for ok, ov in six.iteritems(wscontext.orig_meta):
-			if lname == ok and v == ov:
-				need_set = False
-				break
-		if need_set:
-			meta_set[lname] = v
+    # meta to set?
+    meta_set = {}
+    for k, v in six.iteritems(wscontext.meta):
+        lname = k.lower()
+        need_set = True
+        for ok, ov in six.iteritems(wscontext.orig_meta):
+            if lname == ok and v == ov:
+                need_set = False
+                break
+        if need_set:
+            meta_set[lname] = v
 
-	events = []
-	if wscontext.accepted:
-		events.append(WebSocketEvent('OPEN'))
-	events.extend(wscontext.out_events)
-	if wscontext.closed:
-		events.append(WebSocketEvent('CLOSE', pack('>H', wscontext.out_close_code)))
+    events = []
+    if wscontext.accepted:
+        events.append(WebSocketEvent('OPEN'))
+    events.extend(wscontext.out_events)
+    if wscontext.closed:
+        events.append(WebSocketEvent('CLOSE', pack('>H', wscontext.out_close_code)))
 
-	headers = {'Content-Type': 'application/websocket-events'}
-	if wscontext.accepted:
-		headers['Sec-WebSocket-Extensions'] = 'grip'
-	for k in meta_remove:
-		headers['Set-Meta-' + k] = ''
-	for k, v in six.iteritems(meta_set):
-		headers['Set-Meta-' + k] = v
+    headers = {'Content-Type': 'application/websocket-events'}
+    if wscontext.accepted:
+        headers['Sec-WebSocket-Extensions'] = 'grip'
+    for k in meta_remove:
+        headers['Set-Meta-' + k] = ''
+    for k, v in six.iteritems(meta_set):
+        headers['Set-Meta-' + k] = v
 
-	body = encode_websocket_events(events)
+    body = encode_websocket_events(events)
 
-	return {
-		'isBase64Encoded': True,
-		'statusCode': 200,
-		'headers': headers,
-		'body': b64encode(body)
-	}
+    return {
+        'isBase64Encoded': True,
+        'statusCode': 200,
+        'headers': headers,
+        'body': b64encode(body)
+    }
 
 def lambda_get_websocket(event):
-	lower_headers = {}
-	for k, v in six.iteritems(event.get('headers', {})):
-		lower_headers[k.lower()] = v
+    lower_headers = {}
+    for k, v in six.iteritems(event.get('headers', {})):
+        lower_headers[k.lower()] = v
 
-	content_type = lower_headers.get('content-type')
-	if content_type:
-		at = content_type.find(';')
-		if at != -1:
-			content_type = content_type[:at].strip()
+    content_type = lower_headers.get('content-type')
+    if content_type:
+        at = content_type.find(';')
+        if at != -1:
+            content_type = content_type[:at].strip()
 
-	if event['httpMethod'] != 'POST' or content_type != 'application/websocket-events':
-		raise ValueError('request does not seem to be a websocket-over-http request')
+    if event['httpMethod'] != 'POST' or content_type != 'application/websocket-events':
+        raise ValueError('request does not seem to be a websocket-over-http request')
 
-	cid = lower_headers.get('connection-id')
+    cid = lower_headers.get('connection-id')
 
-	meta = {}
-	for k, v in six.iteritems(lower_headers):
-		if k.startswith('meta-'):
-			meta[k[5:]] = v
+    meta = {}
+    for k, v in six.iteritems(lower_headers):
+        if k.startswith('meta-'):
+            meta[k[5:]] = v
 
-	# read body as binary
-	if event.get('isBase64Encoded'):
-		body = b64decode(event['body'])
-	else:
-		body = event['body']
+    # read body as binary
+    if event.get('isBase64Encoded'):
+        body = b64decode(event['body'])
+    else:
+        body = event['body']
 
-	if is_python3:
-		if isinstance(body, str):
-			body = body.encode('utf-8')
-	else:
-		if isinstance(body, unicode):
-			body = body.encode('utf-8')
+    if is_python3:
+        if isinstance(body, str):
+            body = body.encode('utf-8')
+    else:
+        if isinstance(body, unicode):
+            body = body.encode('utf-8')
 
-	events = decode_websocket_events(body)
+    events = decode_websocket_events(body)
 
-	wscontext = WebSocketContext(cid, meta, events, grip_prefix=_get_prefix())
+    wscontext = WebSocketContext(cid, meta, events, grip_prefix=_get_prefix())
 
-	wscontext.to_response = types.MethodType(lambda_websocket_to_response, wscontext)
+    wscontext.to_response = types.MethodType(lambda_websocket_to_response, wscontext)
 
-	return wscontext
+    return wscontext

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -65,10 +65,12 @@ def get_pubcontrol():
 
 def publish(channel, formats, id=None, prev_id=None, blocking=True, callback=None, meta={}):
     pub = _get_pubcontrol()
-    pub.publish(_get_prefix() + channel,
+    pub.publish(
+        _get_prefix() + channel,
         Item(formats, id=id, prev_id=prev_id, meta=meta),
         blocking=blocking,
-        callback=callback)
+        callback=callback
+    )
 
 
 def lambda_websocket_to_response(wscontext):
@@ -100,7 +102,9 @@ def lambda_websocket_to_response(wscontext):
         events.append(WebSocketEvent('OPEN'))
     events.extend(wscontext.out_events)
     if wscontext.closed:
-        events.append(WebSocketEvent('CLOSE', pack('>H', wscontext.out_close_code)))
+        events.append(
+            WebSocketEvent('CLOSE', pack('>H', wscontext.out_close_code))
+        )
 
     headers = {'Content-Type': 'application/websocket-events'}
     if wscontext.accepted:
@@ -131,8 +135,11 @@ def lambda_get_websocket(event):
         if at != -1:
             content_type = content_type[:at].strip()
 
-    if event['httpMethod'] != 'POST' or content_type != 'application/websocket-events':
-        raise ValueError('request does not seem to be a websocket-over-http request')
+    if (event['httpMethod'] != 'POST'
+            or content_type != 'application/websocket-events'):
+        raise ValueError(
+            'request does not seem to be a websocket-over-http request'
+        )
 
     cid = lower_headers.get('connection-id')
 
@@ -158,6 +165,9 @@ def lambda_get_websocket(event):
 
     wscontext = WebSocketContext(cid, meta, events, grip_prefix=_get_prefix())
 
-    wscontext.to_response = types.MethodType(lambda_websocket_to_response, wscontext)
+    wscontext.to_response = types.MethodType(
+        lambda_websocket_to_response,
+        wscontext
+    )
 
     return wscontext

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 import threading
 import types
 from base64 import b64encode, b64decode
@@ -56,7 +55,8 @@ def get_pubcontrol():
     return _get_pubcontrol()
 
 
-def publish(channel, formats, id=None, prev_id=None, blocking=True, callback=None, meta={}):
+def publish(channel, formats, id=None, prev_id=None,
+            blocking=True, callback=None, meta={}):
     pub = _get_pubcontrol()
     pub.publish(
         _get_prefix() + channel,

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -16,6 +16,7 @@ is_python3 = sys.version_info >= (3,)
 _pubcontrol = None
 _lock = threading.Lock()
 
+
 def _is_basestring_instance(instance):
     try:
         if isinstance(instance, basestring):
@@ -24,6 +25,7 @@ def _is_basestring_instance(instance):
         if isinstance(instance, str):
             return True
     return False
+
 
 def _get_proxies():
     proxies = []
@@ -35,6 +37,7 @@ def _get_proxies():
         proxies.append(parse_grip_uri(grip_url))
     return proxies
 
+
 def _get_pubcontrol():
     global _pubcontrol
     _lock.acquire()
@@ -44,11 +47,14 @@ def _get_pubcontrol():
     _lock.release()
     return _pubcontrol
 
+
 def _get_prefix():
     return os.environ.get('GRIP_PREFIX', '')
 
+
 def get_pubcontrol():
     return _get_pubcontrol()
+
 
 def publish(channel, formats, id=None, prev_id=None, blocking=True, callback=None, meta={}):
     pub = _get_pubcontrol()
@@ -56,6 +62,7 @@ def publish(channel, formats, id=None, prev_id=None, blocking=True, callback=Non
         Item(formats, id=id, prev_id=prev_id, meta=meta),
         blocking=blocking,
         callback=callback)
+
 
 def lambda_websocket_to_response(wscontext):
     # meta to remove?
@@ -104,6 +111,7 @@ def lambda_websocket_to_response(wscontext):
         'headers': headers,
         'body': b64encode(body)
     }
+
 
 def lambda_get_websocket(event):
     lower_headers = {}

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -16,7 +16,6 @@ from gripcontrol import (
 )
 from pubcontrol import Item
 
-
 # The PubControl instance and lock used for synchronization.
 _pubcontrol = None
 _lock = threading.Lock()

--- a/faas_grip.py
+++ b/faas_grip.py
@@ -17,7 +17,6 @@ from gripcontrol import (
 )
 from pubcontrol import Item
 
-is_python3 = sys.version_info >= (3,)
 
 # The PubControl instance and lock used for synchronization.
 _pubcontrol = None
@@ -148,12 +147,8 @@ def lambda_get_websocket(event):
     else:
         body = event['body']
 
-    if is_python3:
-        if isinstance(body, str):
-            body = body.encode('utf-8')
-    else:
-        if isinstance(body, unicode):
-            body = body.encode('utf-8')
+    if isinstance(body, six.text_type):
+        body = body.encode('utf-8')
 
     events = decode_websocket_events(body)
 


### PR DESCRIPTION
+ Replace each tab character with four spaces
    > [Use 4 spaces per indentation level.](http://pep8.org/#indentation)
+ Two blank lines before top-level definitions
    > [Surround top-level function and class definitions with two blank lines.](http://pep8.org/#blank-lines)
+ [Group imports according to PEP8 (standard, third-party, local)](http://pep8.org/#imports)
+ Use consistent indentation, format lines longer than 79 chars
+ Use `six.string_types`
    > [Possible types for text data. This is basestring() in Python 2 and str in Python 3.](https://pythonhosted.org/six/#six.string_types)
+ Use `six.text_type`
    > [Type for representing (Unicode) textual data. This is unicode() in Python 2 and str in Python 3.](https://pythonhosted.org/six/#six.text_type)
+ Remove unused import
